### PR TITLE
teste nonNumericJobId no arquivo showjobtest

### DIFF
--- a/BackEnd/tests/Feature/Job/ShowJobTest.php
+++ b/BackEnd/tests/Feature/Job/ShowJobTest.php
@@ -170,7 +170,6 @@ class ShowJobTest extends TestCase
 
     public function testNonNumericJobId()
     {
-        $jobId = Job::max('id') + 1;
         $this->makeRecruiter();
         
         $this

--- a/BackEnd/tests/Feature/Job/ShowJobTest.php
+++ b/BackEnd/tests/Feature/Job/ShowJobTest.php
@@ -167,5 +167,27 @@ class ShowJobTest extends TestCase
                 ]
             ]);
     }
+
+    public function testNonNumericJobId()
+    {
+        $jobId = Job::max('id') + 1;
+        $this->makeRecruiter();
+        
+        $this
+            ->actingAs($this->employee)
+            ->json('GET', sprintf(self::ROUTE, 'not an integer'))
+            ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+            ->assertJsonStructure([
+                'message',
+                'additional_info' => [
+                    'job_id'
+                ]
+            ])->assertJson([
+                'message' => 'Job id must be an integer',
+                'additional_info' => [
+                    'job_id' => 'not an integer'
+                ]
+            ]);
+    }
 }
 


### PR DESCRIPTION
Implementação do teste que verifica a exception quando o jobId não for um inteiro.